### PR TITLE
Corrects a minor mistake in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Snapshots are regularly uploaded to the Sonatype OSSRH (OSS Repository Hosting) 
 If you are embedding the NATS Gatling connector, add the following dependency to your project's `build.sbt` file.
 
 ```scala
-libraryDependencies += "com.logimethods" %% "nats-connector-gatling" % "0.2.0-SNAPSHOT"
+libraryDependencies += "com.logimethods" %% "nats-connector-gatling_2.11" % "0.2.0-SNAPSHOT"
 ```
 If you don't already have your build configured for using Maven snapshots, you'll also need to add the following repository.
 


### PR DESCRIPTION
The snapshot instructions for testing 0.2.0 appear to have the wrong
artifact name. For 0.2.0-SNAPSHOT the artifact is still
`nats-connector-gatling_2.11`. Correct this in the documentation.
